### PR TITLE
Use pyproject.toml and .flake8 instead of setup.cfg and .coveragerc

### DIFF
--- a/{{cookiecutter.project_directory}}/.coveragerc
+++ b/{{cookiecutter.project_directory}}/.coveragerc
@@ -1,2 +1,0 @@
-[report]
-omit = {{cookiecutter.plugin_package}}/qgis_plugin_tools/*

--- a/{{cookiecutter.project_directory}}/.flake8
+++ b/{{cookiecutter.project_directory}}/.flake8
@@ -5,8 +5,3 @@ exclude = test_*
 extend-ignore =
             E203, # whitespace before ':'
             ANN101 # Missing type annotation for self in method
-
-[isort]
-# Black compatible values for isort https://black.readthedocs.io/en/stable/compatible_configs.html#isort
-profile = black
-multi_line_output = 3

--- a/{{cookiecutter.project_directory}}/pyproject.toml
+++ b/{{cookiecutter.project_directory}}/pyproject.toml
@@ -1,7 +1,6 @@
 [tool.isort]
 # Black compatible values for isort https://black.readthedocs.io/en/stable/compatible_configs.html#isort
 profile = "black"
-multi_line_output = 3
 
 [tool.pytest.ini_options]
 addopts = "-v"

--- a/{{cookiecutter.project_directory}}/pyproject.toml
+++ b/{{cookiecutter.project_directory}}/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.isort]
+# Black compatible values for isort https://black.readthedocs.io/en/stable/compatible_configs.html#isort
+profile = "black"
+multi_line_output = 3
+
+[tool.pytest.ini_options]
+addopts = "-v"
+
+[tool.coverage.report]
+omit = "{{cookiecutter.plugin_package}}/qgis_plugin_tools/*"


### PR DESCRIPTION
This PR refactors the template to use pyproject.toml and .flake8 instead of setup.cfg and .coveragerc.