### PR TITLE
Remove long package name handling

### DIFF
--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -68,7 +68,7 @@ def baked_project(
     if isinstance(baked_project.exception, UndefinedVariableInTemplate):
         print(baked_project.exception.message)  # noqa: T201
         print(f"Error message: {baked_project.exception.error.message}")  # noqa: T201
-        sys.exit(1)
+        pytest.fail("Undefined variable in template")
 
     return baked_project
 

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -13,8 +13,6 @@ if TYPE_CHECKING:
 
     from pytest_cookies.plugin import Cookies, Result
 
-LONG_PACKAGE_NAME = "hyperextralongpackagenametomessupimportformatting"
-
 
 @pytest.fixture(scope="session")
 def session_context():
@@ -39,7 +37,6 @@ def context(session_context: dict[str, str]):
 
 SUPPORTED_COMBINATIONS = [
     {},  # test with default values
-    {"plugin_package": LONG_PACKAGE_NAME},
     {"ci_provider": "None"},
     {"add_vscode_config": True},
     {"include_processing": True},
@@ -104,17 +101,11 @@ def run_cli_command(args: list[str], cwd: str):
 def test_ruff_linting_passes(baked_project: Result):
     """Generated project should pass ruff check."""
 
-    if baked_project.context["plugin_package"] == LONG_PACKAGE_NAME:
-        pytest.xfail(reason="long package names makes imports to be reformatted. TODO: fix")
-
     run_cli_command([sys.executable, "-m", "ruff", "check", "."], cwd=str(baked_project.project_path))
 
 
 def test_ruff_formatting_passes(baked_project: Result):
     """Generated project should pass ruff formatting."""
-
-    if baked_project.context["plugin_package"] == LONG_PACKAGE_NAME:
-        pytest.xfail(reason="long package names makes imports to be reformatted. TODO: fix")
 
     run_cli_command([sys.executable, "-m", "ruff", "format", "--check", "."], cwd=str(baked_project.project_path))
 

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -38,12 +38,13 @@ def context(session_context: dict[str, str]):
 
 
 SUPPORTED_COMBINATIONS = [
-    {},
+    {},  # test with default values
     {"plugin_package": LONG_PACKAGE_NAME},
     {"ci_provider": "None"},
     {"add_vscode_config": True},
     {"include_processing": True},
-    {"use_qgis_plugin_tools": True},
+    {"use_qgis_plugin_tools": True, "include_processing": True},
+    {"use_qgis_plugin_tools": True, "include_processing": False},
     {"license": "GPL3"},
 ]
 

--- a/{{cookiecutter.project_directory}}/plugin_templates/plugin_with_submodule.py.j2
+++ b/{{cookiecutter.project_directory}}/plugin_templates/plugin_with_submodule.py.j2
@@ -11,6 +11,7 @@ from qgis.PyQt.QtWidgets import QAction, QWidget
 from qgis.utils import iface
 
 {% if cookiecutter.include_processing -%}
+from {{cookiecutter.plugin_package}}.{{cookiecutter.plugin_package}}_processing.provider import Provider
 {% endif -%}
 {% if cookiecutter.plugin_package|length < 7 -%}
 from {{cookiecutter.plugin_package}}.qgis_plugin_tools.tools.custom_logging import setup_logger, teardown_logger

--- a/{{cookiecutter.project_directory}}/plugin_templates/plugin_with_submodule.py.j2
+++ b/{{cookiecutter.project_directory}}/plugin_templates/plugin_with_submodule.py.j2
@@ -13,14 +13,7 @@ from qgis.utils import iface
 {% if cookiecutter.include_processing -%}
 from {{cookiecutter.plugin_package}}.{{cookiecutter.plugin_package}}_processing.provider import Provider
 {% endif -%}
-{% if cookiecutter.plugin_package|length < 7 -%}
 from {{cookiecutter.plugin_package}}.qgis_plugin_tools.tools.custom_logging import setup_logger, teardown_logger
-{% else -%}
-from {{cookiecutter.plugin_package}}.qgis_plugin_tools.tools.custom_logging import (
-    setup_logger,
-    teardown_logger,
-)
-{% endif -%}
 from {{cookiecutter.plugin_package}}.qgis_plugin_tools.tools.i18n import setup_translation
 from {{cookiecutter.plugin_package}}.qgis_plugin_tools.tools.resources import plugin_name
 

--- a/{{cookiecutter.project_directory}}/{{cookiecutter.plugin_package}}/{{cookiecutter.plugin_package}}_processing/provider.py.j2
+++ b/{{cookiecutter.project_directory}}/{{cookiecutter.plugin_package}}/{{cookiecutter.plugin_package}}_processing/provider.py.j2
@@ -1,6 +1,6 @@
 from qgis.core import QgsProcessingProvider
 
-from {{cookiecutter.plugin_package}}.{{cookiecutter.plugin_package}}_processing.processing_algorithm import ProcessingAlgorithm  # type: ignore[import-not-found]
+from {{cookiecutter.plugin_package}}.{{cookiecutter.plugin_package}}_processing.processing_algorithm import ProcessingAlgorithm
 
 
 class Provider(QgsProcessingProvider):


### PR DESCRIPTION
The main change in this PR:
Since we have extended the approved line length to 120 it is unlikely that imports should be reformatted. For example with that one conditional formatting the package name could be 38 chars long before alternative formatting should occur. This should be a rare case and it's okay to let a user to fix that.

Contains also few small not related fixes.

Resolves #19 by leaving the possible issue to user to resolve